### PR TITLE
[DSD - Marine Vessel Registry #68299] - Restore filters dropdown list of request table to original state

### DIFF
--- a/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/Column.razor.cs
+++ b/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/Column.razor.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using DSD.MSS.Blazor.Components.Table.Models;
+using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace DSD.MSS.Blazor.Components.Table
@@ -19,6 +21,9 @@ namespace DSD.MSS.Blazor.Components.Table
         public ITable<TableItem> Table { get; set; }
 
         private string _title;
+
+        [CascadingParameter(Name = "TableSettings")]
+        public TableSettings<TableItem> TableSettings { get; set; }
 
         /// <summary>
         /// Title (Optional, will use Field Name if null)
@@ -175,6 +180,50 @@ namespace DSD.MSS.Blazor.Components.Table
             {
                 this.SortColumn = DefaultSortColumn.Value;
             }
+            Table.Update();
+        }
+
+        /// <summary>
+        /// Lifecycle method used to handle column filter reloading if it exists from previous page navigation
+        /// </summary>
+        /// <param name="firstRender">Is this the applications first render</param>
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if(firstRender)
+            {
+                ColumnFilterSelectedItems = TableSettings.Columns.FirstOrDefault(f => f.Title == Title)?.ColumnFilterSelectedItems ?? new List<string>();
+                if(ColumnFilterSelectedItems.Any())
+                {
+                    Expression<Func<TableItem, bool>> expression = GetStringFilter(this, ColumnFilterSelectedItems.First());
+                    Expression body = expression.Body;
+                    foreach (var itemName in ColumnFilterSelectedItems.Skip(1))
+                    {
+                        expression = GetStringFilter(this, itemName);
+                        body = Expression.Or(body, expression.Body);
+                    }
+                    Filter = Expression.Lambda<Func<TableItem, bool>>(body, Field.Parameters);
+                    Table.Update();
+                }
+            }
+            base.OnAfterRender(firstRender);
+        }
+
+        /// <summary>
+        /// Gets the value to filter against the encapsulating column
+        /// </summary>
+        /// <param name="column">The column</param>
+        /// <param name="FilterText">The value to filter against</param>
+        /// <returns></returns>
+        private Expression<Func<TableItem, bool>> GetStringFilter(IColumn<TableItem> column, string FilterText)
+        {
+            return Expression.Lambda<Func<TableItem, bool>>(
+                       Expression.AndAlso(
+                           Expression.NotEqual(column.Field.Body, Expression.Constant(null)),
+                           Expression.Call(
+                               column.Field.Body,
+                               typeof(string).GetMethod(nameof(string.Equals), new[] { typeof(string), typeof(StringComparison) }),
+                               new[] { Expression.Constant(FilterText), Expression.Constant(StringComparison.OrdinalIgnoreCase) })),
+                       column.Field.Parameters);
         }
 
         protected override void OnParametersSet()

--- a/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/Table.razor
+++ b/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/Table.razor
@@ -182,5 +182,8 @@
 }
 
 <CascadingValue Value="(ITable<TableItem>)this" Name="Table">
-    @ChildContent
+    <CascadingValue Value="TableSettings" Name="TableSettings">
+        @ChildContent
+    </CascadingValue>
+    
 </CascadingValue>

--- a/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/Table.razor.cs
+++ b/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/Table.razor.cs
@@ -20,6 +20,12 @@ namespace DSD.MSS.Blazor.Components.Table
         public IReadOnlyDictionary<string, object> UnknownParameters { get; set; }
 
         /// <summary>
+        /// Contains the filtering options carried over from the previous page visit, and is cascaded down to children for use.
+        /// </summary>
+        [Parameter]
+        public TableSettings<TableItem> TableSettings { get; set; }
+
+        /// <summary>
         /// Table CSS Class (Defaults to Bootstrap 4)
         /// </summary>
         [Parameter]

--- a/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/TableHeaderFilter.razor
+++ b/BlazorTable/DSD.MSS.Blazor.Components.Table/Components/TableHeaderFilter.razor
@@ -38,7 +38,10 @@
                         {
                             <li>
                                 <label>
-                                    <input type="checkbox" @onchange="args => { OnCheckboxClicked(column, item, args.Value); }">@item
+                                    <input 
+                                           type="checkbox" 
+                                           checked="@column.ColumnFilterSelectedItems.Contains(item)"
+                                           @onchange="args => { OnCheckboxClicked(column, item, args.Value); }">@item
                                 </label>
                             </li>
                         }

--- a/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Data/TableData.cs
+++ b/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Data/TableData.cs
@@ -16,8 +16,8 @@ namespace DSD.MSS.Blazor.Components.Table.Demo.Data
                 list.Add(new TableModel()
                 {
                     Id = i.ToString(),
-                    FirstName = "Mark",
-                    LastName = "Otto",
+                    FirstName = "Mark " + i,
+                    LastName = "Otto " + i,
                     Handle = "@mdo" + i.ToString()
                 });
             }

--- a/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Pages/Index.razor
+++ b/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Pages/Index.razor
@@ -34,7 +34,7 @@
 
                 <Table TableClass="table table-striped table-hover" GlobalSearch="@tableSettings.GlobalSearch" TableItem="TableModel"
                        @ref="TableRef" PageSize="@tableSettings.PageSize" PageNumber="@tableSettings.PageNumber" ShowSearchBar="@ShowFilterHeader"
-                       Items="tableData" HeaderFilterChanged="@(()=>HandleHeaderFilterChanged())"
+                       Items="tableData" HeaderFilterChanged="@(()=>HandleHeaderFilterChanged())" TableSettings="tableSettings"
                        FilterChanged="(e)=>OnFilterChanged(e)">
                     <Column TableItem="TableModel" Title="#" Field="@(x => x.Id)" Sortable="false" Width="25%" />
                     <Column TableItem="TableModel" Title="First Name" Field="@(x => x.FirstName)" HeaderRowFilterable="@FirstNameFilter" Sortable="true" Width="25%" />

--- a/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Pages/ListOfValues.razor
+++ b/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Pages/ListOfValues.razor
@@ -1,0 +1,7 @@
+﻿@page "/listofvalues"
+
+<h3>ListOfViews</h3>
+
+@code {
+
+}

--- a/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Shared/NavMenu.razor
+++ b/DemoWebsites/BlazorComponentTableDemoSite/DSD.MSS.Blazor.Components.Table.Demo/Shared/NavMenu.razor
@@ -11,6 +11,9 @@
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
+            <NavLink class="nav-link" href="/listofvalues">
+                <span class="oi oi-home" aria-hidden="true"></span> List of Values
+            </NavLink>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Changes:

- Added cascading value to Table Component
- Updated Column Component to accept a cascading parameter and check previous page visit value. Then if a previous filter was set, it will update the checkboxes and filter the table content.
- Add checked default value on page load to TableHeader component filter dropdown
- Updated Demo website to reflect additional cascading parameters
- Created a new blazor page to simulate page changes
- Added page menu link to Nav Menu